### PR TITLE
Fix numerical instability and NaN gradients in `model_s` replication probability

### DIFF
--- a/scdna_replication_tools/pert_model.py
+++ b/scdna_replication_tools/pert_model.py
@@ -615,12 +615,8 @@ class pert_infer_scRT():
                 # per cell per bin late or early 
                 t_diff = tau.reshape(-1, num_cells) - rho.reshape(num_loci, -1)
 
-                # probability of having been replicated
-                phi = 1 / (1 + torch.exp(-a * t_diff))
-
-                # force phi to remain on the domain of 0.001 to 0.999
-                phi[phi<0.001] = 0.001
-                phi[phi>0.999] = 0.999
+                eps = torch.finfo(t_diff.dtype).eps
+                phi = torch.clamp(torch.sigmoid(a * t_diff), min=eps, max=1.0 - eps)
 
                 # binary replicated indicator
                 rep = pyro.sample('rep', dist.Bernoulli(phi), infer={"enumerate": "parallel"})


### PR DESCRIPTION
**Summary of Changes:**
This PR fixes a numerical instability edge-case in `pert_model.py` that causes NaN gradient issues and CUDA crashes during longer training.

It replaces the manual sigmoid calculation and in-place tensor masking with PyTorch's native `torch.sigmoid()` and `torch.clamp()`, and uses dynamic machine epsilon to maximize the dynamic range safely.

**Changing Functionality:**
The original code set bounds of 0.001 and 0.999 on the value of `phi`. I assume these were intended to avoid overflow errors - however I have replaced the hardcoded 0.001 buffer with `torch.finfo.eps` to maximize the dynamic range across any hardware precision.

To retain the original bounds with the native PyTorch functionality, instead use:
```Python
phi = torch.clamp(torch.sigmoid(a * t_diff), min=0.001, max=0.999)
```

**Testing:**
Validated locally on a clinical scDNA-seq dataset (float32 on GPU) that was consistently crashing at iteration ~3,800 due to NaN propagation. With this change, the model safely and smoothly converges through all specified iterations.

Fixes #15